### PR TITLE
Update termplot.R

### DIFF
--- a/src/library/stats/R/termplot.R
+++ b/src/library/stats/R/termplot.R
@@ -133,7 +133,7 @@ termplot <- function(model, data = NULL, envir = environment(formula(model)),
         if (!is.null(which.terms)) pres <- pres[, which.terms, drop = FALSE]
     }
 
-    se.lines <- function(x, iy, i, ff = 2) {
+    se.lines <- function(x, iy, i, ff = 1) {
         tt <- ff * terms$se.fit[iy, i]
         lines(x, tms[iy, i] + tt, lty = lty.se, lwd = lwd.se, col = col.se)
         lines(x, tms[iy, i] - tt, lty = lty.se, lwd = lwd.se, col = col.se)

--- a/src/library/stats/R/termplot.R
+++ b/src/library/stats/R/termplot.R
@@ -18,7 +18,7 @@
 
 termplot <- function(model, data = NULL, envir = environment(formula(model)),
                      partial.resid = FALSE,
-		     rug = FALSE, terms = NULL, se = FALSE,
+		     rug = FALSE, terms = NULL, se = FALSE, ff=1,
                      xlabs = NULL, ylabs = NULL,
                      main = NULL, col.term = 2, lwd.term = 1.5,
                      col.se = "orange", lty.se = 2, lwd.se = 1,
@@ -133,7 +133,7 @@ termplot <- function(model, data = NULL, envir = environment(formula(model)),
         if (!is.null(which.terms)) pres <- pres[, which.terms, drop = FALSE]
     }
 
-    se.lines <- function(x, iy, i, ff = 1) {
+    se.lines <- function(x, iy, i, ff = ff) {
         tt <- ff * terms$se.fit[iy, i]
         lines(x, tms[iy, i] + tt, lty = lty.se, lwd = lwd.se, col = col.se)
         lines(x, tms[iy, i] - tt, lty = lty.se, lwd = lwd.se, col = col.se)


### PR DESCRIPTION
The help page for termplot states that it adds (optionally) standard errors around the partial plots for each predictor.  However, until now it has multiplied the standard error (returned by predict() function) by 2.0, to generate an approximate 95% confidence interval, rather than a standard error.