### PR TITLE
Correction constrOptim.R

### DIFF
--- a/src/library/stats/R/constrOptim.R
+++ b/src/library/stats/R/constrOptim.R
@@ -63,11 +63,11 @@ constrOptim <-
         a <- optim(theta.old, fun, gradient, control = control,
                    method = method, hessian = hessian, ...)
         r <- a$value
-        if (is.finite(r) && is.finite(r.old) &&
- 	    abs(r - r.old) < (1e-3 + abs(r)) * outer.eps) break
+        totCounts <- totCounts + a$counts
         theta <- a$par
- 	totCounts <- totCounts + a$counts
         obj <- f(theta, ...)
+        if (is.finite(r) && is.finite(r.old) &&
+ 	          abs(r - r.old) < (1e-3 + abs(r)) * outer.eps) break
         if (s.mu * obj > s.mu * obj.old) break
     }
     if (i == outer.iterations) {

--- a/src/library/stats/R/constrOptim.R
+++ b/src/library/stats/R/constrOptim.R
@@ -67,7 +67,7 @@ constrOptim <-
         theta <- a$par
         obj <- f(theta, ...)
         if (is.finite(r) && is.finite(r.old) &&
- 	          abs(r - r.old) < (1e-3 + abs(r)) * outer.eps) break
+ 	        abs(r - r.old) < (1e-3 + abs(r)) * outer.eps) break
         if (s.mu * obj > s.mu * obj.old) break
     }
     if (i == outer.iterations) {


### PR DESCRIPTION
The following unexpected behaviour of the constrOptim function occurs:
1. The totCounts variable remains zero if only one outer iteration is performed, due to the following break:
`if (is.finite(r) && is.finite(r.old) &&
 	    abs(r - r.old) < (1e-3 + abs(r)) * outer.eps) break`,  This is unexpected, because the R Documentation says: 
_The counts component contains the sum of **all** optim()$counts._  Hence, the total counts have to updated earlier in the loop.
2. The if-clauses behind the loop should correspond to `f(theta,...)` where `theta` is the parameter vector after the last `optim`-call in the loop.

Am I right with my suggestions?